### PR TITLE
More portable lookup for `bash`

### DIFF
--- a/cci-config-generator.sh
+++ b/cci-config-generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to generate a CircleCI 2.0 `.circleci/config.yml` file
 # Please see the README for more details


### PR DESCRIPTION
A less precise lookup but possibly more portable across various OS (in my case, `bash` does not reside in `/bin` under NixOS)